### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "aws/aws-sdk-php" : "3.62.*",
+        "aws/aws-sdk-php" : "3.*",
         "ext-libxml" : "*",
         "ext-simplexml" : "*"
     },


### PR DESCRIPTION
AWS/aws-sdk-php library was over 200 versions out of date. Have updated composer.json to accept all minor versions of version 3 of library.